### PR TITLE
I18n

### DIFF
--- a/rockspec/cosyverif-master-1.rockspec
+++ b/rockspec/cosyverif-master-1.rockspec
@@ -33,6 +33,7 @@ dependencies = {
   "lualogging >= 1",
   "luasec >= 0",
   "luasocket >= 2",
+  "lustache >= 1",
   "redis-lua >= 2",
   "serpent >= 0",
 }

--- a/src/cosy-i18n.lua
+++ b/src/cosy-i18n.lua
@@ -1,0 +1,14 @@
+return {
+  ["daemon:unreachable"] = {
+    en = "cosy daemon is unreachable",
+    fr = "le démon cosy est injoignable",
+  },
+  ["command:missing"] = {
+    en = "missing the command to run: {{{cli}}} <command> [parameters...]",
+    fr = "commande non spécifiée: {{{cli}}} <commande> [paramètres...]",
+  },
+  ["command:available"] = {
+    en = "available commands are:",
+    fr = "les commandes disponibles sont:",
+  },
+}

--- a/src/cosy/commands-i18n.lua
+++ b/src/cosy/commands-i18n.lua
@@ -1,0 +1,47 @@
+return {
+  ["daemon:stop"] = {
+    en = "stop cosy daemon",
+  },
+  ["server:start"] = {
+    en = "start cosy server",
+  },
+  ["server:stop"] = {
+    en = "stop cosy server",
+  },
+  ["server:already-running"] = {
+    en = "server is already running",
+  },
+  ["option:server"]= {
+    en = "server url"
+  },
+  ["option:locale"] = {
+    en = "locale for messages",
+  },
+  ["show:information"] = {
+    en = "show information about the server",
+  },
+  ["show:tos"] = {
+    en = "show the terms of service of the server",
+  },
+  ["user:create"] = {
+    en = "create a user account on the server",
+  },
+  ["argument:username"] = {
+    en = "username",
+  },
+  ["argument:email"] = {
+    en = "email address",
+  },
+  ["argument:password1"] = {
+    en = "please type your password:";
+  },
+  ["argument:password2"] = {
+    en = "please type again the same password:",
+  },
+  ["argument:password:nomatch"] = {
+    en = "entered passwords differ",
+  },
+  ["option:clean"] = {
+    en = "clean redis database before launching the server",
+  },
+}

--- a/src/cosy/configuration-i18n.lua
+++ b/src/cosy/configuration-i18n.lua
@@ -1,0 +1,14 @@
+return {
+  ["updated"] = {
+    en = "configuration has been updated",
+    fr = "la configuration vient d'être mise à jour",
+  },
+  ["use"] = {
+    en = "using file {{{path}}} in configuration",
+    fr = "la configuration utilise le fichier {{{path}}}",
+  },
+  ["skip"] = {
+    en = "skipping file {{{path}}} in configuration",
+    fr = "la configuration n'utilise pas le fichier {{{path}}}",
+  },
+}

--- a/src/cosy/configuration.lua
+++ b/src/cosy/configuration.lua
@@ -1,8 +1,10 @@
 local Loader        = require "cosy.loader"
+local I18n          = require "cosy.i18n"
 local Logger        = require "cosy.logger"
 local Repository    = require "cosy.repository"
 local Scheduler     = require "cosy.scheduler"
 
+local i18n       = I18n.load (require "cosy.configuration-i18n")
 local repository = Repository.new ()
 
 Repository.options (repository).create = function () return {} end
@@ -52,7 +54,7 @@ if not _G.js then
         local url    = tostring (source._)
         if url:match "^http" then
           script [#script+1] = ([[
-            redis.call ("set", "foreign:%{name}", "%{source}")
+            redis.call ("set", "foreign:{{{name}}}", "{{{source}}}")
           ]]) % {
             name   = name,
             source = url,
@@ -65,12 +67,12 @@ if not _G.js then
       script = table.concat (script)
       redis:eval (script, 1, "foreign:*")
       os.execute ([[
-        find %{root}/cache -type f -delete
+        find {{{root}}}/cache -type f -delete
       ]] % {
         root = Nginx.directory,
       })
       Logger.debug {
-        _ = "configuration:updated",
+        _ = i18n ["updated"],
       }
       Nginx.update ()
       Scheduler.sleep (-math.huge)
@@ -96,14 +98,14 @@ if not _G.js then
         Scheduler.wakeup (updater)
       end
       Logger.debug {
-        _      = "configuration:using",
+        _      = i18n ["use"],
         path   = name,
         locale = repository.whole.locale._ or "en",
       }
       repository [key] = result
     else
       Logger.warning {
-        _      = "configuration:skipping",
+        _      = i18n ["skip"],
         path   = name,
         locale = repository.whole.locale._ or "en",
       }

--- a/src/cosy/configuration/default.lua
+++ b/src/cosy/configuration/default.lua
@@ -78,7 +78,7 @@ return {
   statistics = "http://stats.cosyverif.org",
   cli = {
     directory      = os.getenv "HOME" .. "/.cosy",
-    default_locale = (os.getenv "LANG" or "en"):match "[^%.]+",
+    default_locale = (os.getenv "LANG" or "en"):match "[^%.]+":gsub ("_", "-"),
     default_server = "http://cosyverif.org/",
   },
 }

--- a/src/cosy/daemon-i18n.lua
+++ b/src/cosy/daemon-i18n.lua
@@ -1,0 +1,9 @@
+return {
+  ["server:unreachable"] = {
+    en = "cosy server is unreachable",
+    fr = "le serveur cosy est injoignable",
+  },
+  ["websocket:listen"] = {
+    en = "daemon websocket listening on {{{host}}}:{{{port}}}",
+  },
+}

--- a/src/cosy/email-i18n.lua
+++ b/src/cosy/email-i18n.lua
@@ -1,0 +1,11 @@
+return {
+  ["smtp:not-available"] = {
+    en = "no SMTP server discovered, sending of emails will not work",
+  },
+  ["smtp:available"] = {
+    en = "SMTP on {{{host}}}:{{{port}}} uses {{{method}}} (encrypted with {{{protocol}}})",
+  },
+  ["smtp:discover"] = {
+    en = "discovering SMTP on {{{host}}}:{{{port}}} using {{{method}}} (encrypted with {{{protocol}}})",
+  },
+}

--- a/src/cosy/email.lua
+++ b/src/cosy/email.lua
@@ -6,6 +6,9 @@ local Socket        = require "socket"
 local Smtp          = require "socket.smtp"
 local Ssl           = require "ssl"
 
+local i18n   = I18n.load (require "cosy.email-i18n")
+i18n._locale = Configuration.locale._
+
 if _G.js then
   error "Not available"
 end
@@ -153,7 +156,7 @@ function Email.discover ()
     for _, protocol in ipairs (protos) do
       for _, port in ipairs (ports) do
         Logger.debug {
-          _        = "smtp:discover",
+          _        = i18n ["smtp:discover"],
           host     = host,
           port     = port,
           method   = method,
@@ -208,11 +211,11 @@ end
 do
   if not Email.discover () then
     Logger.warning {
-      _ = "smtp:not-available",
+      _ = i18n ["smtp:not-available"],
     }
   else
     Logger.info {
-      _        = "smtp:available",
+      _        = i18n ["smtp:available"],
       host     = Configuration.smtp.host._,
       port     = Configuration.smtp.port._,
       method   = Configuration.smtp.method._,

--- a/src/cosy/i18n.lua
+++ b/src/cosy/i18n.lua
@@ -1,61 +1,84 @@
-local i18n = require "i18n"
+local Lustache = require "lustache"
+local Plural   = require "i18n.plural"
 
-return function (x)
-  if type (x) ~= "table" then
-    return x
-  end
-  local locale  = x.locale
-  if not locale then
-    locale = "en"
-  end
-  while locale do
-    local Loader      = require "cosy.loader"
-    local Logger      = require "cosy.logger"
-    local package     = "cosy.i18n." .. locale
-    local loaded      = Loader.hotswap.loaded [package]
-    local translation = Loader.hotswap.try_require (package)
-    if translation and not loaded then
-      i18n.load {
-        [locale] = translation,
-      }
-      Logger.info {
-        _      = "locale:available",
-        loaded = locale,
-        locale = locale,
-      }
-      break
-    elseif translation then
-      break
-    end
-    Logger.info {
-      _      = "locale:missing",
-      loaded = locale,
-      locale = "en",
-    }
-    local main, sub = locale:match "(%w+)_(%w+)"
-    if main and sub then
-      locale = main
-    else
-      locale = nil
-    end
-  end
+local I18n      = {}
+local Metatable = {}
+local Message   = {}
 
+setmetatable (I18n, Metatable)
+
+function I18n.load (t)
+  return setmetatable ({
+    _store  = t,
+    _locale = "en",
+  }, I18n)
+end
+
+function I18n.__index (i18n, key)
+  local entry = i18n._store [key]
+  if not entry then
+    return nil
+  end
+  return setmetatable ({
+    _key    = key,
+    _entry  = entry,
+    _locale = i18n._locale,
+  }, Message)
+end
+
+function I18n.__call (i18n, data)
+  local locale = data.locale or i18n._locale
   local function translate (t)
     if type (t) ~= "table" then
       return t
     end
     for _, v in pairs (t) do
       if type (v) == "table" and not getmetatable (v) then
-        local vl  = v.locale
-        v.locale  = t.locale
         translate (v)
-        v.locale  = vl
       end
     end
-    if t._ then
-      t.message = i18n.translate (t._, t)
+    if t._ and getmetatable (t._) == Message then
+      t.locale  = t.locale or locale
+      t.message =  t._ % t
     end
-    return x
+    return t.message
   end
-  return tostring (translate (x).message)
+  return translate (data)
 end
+
+Metatable.__call = I18n.__call
+
+function Message.__mod (message, context)
+  local locale = context.locale or message._locale
+  locale = locale:lower ()
+  locale = locale:gsub ("_", "-")
+  locale = locale:match "^(%w%w-%w%w)" or locale:match "^(%w%w)"
+  if not message._entry [locale] then
+    locale = locale:match "^(%w%w)"
+  end
+  if not message._entry [locale] then
+    locale = message._locale
+  end
+  if not message._entry [locale] then
+    locale = locale:match "^(%w%w)"
+  end
+  if not message._entry [locale] then
+    locale = "en"
+  end
+  if not message._entry [locale] then
+    local Value = require "cosy.value"
+    return Value.expression (message._key) .. ":" .. Value.expression (context)
+  end
+  local result = message._entry [locale]
+  local t      = {}
+  for k, v in pairs (context) do
+    t [k] = v
+    if type (v) == "number" then
+      assert (context ["~" .. k] == nil)
+      t ["~" .. k] = Plural.get (locale, v)
+    end
+  end
+  return Lustache:render (result, context)
+end
+
+return I18n

--- a/src/cosy/library-i18n.lua
+++ b/src/cosy/library-i18n.lua
@@ -1,0 +1,9 @@
+return {
+  ["server:unreachable"] = {
+    en = "cosy server is unreachable",
+    fr = "le serveur cosy est injoignable",
+  },
+  ["server:timeout"] = {
+    en = "timeout while waiting response from server",
+  },
+}

--- a/src/cosy/library.lua
+++ b/src/cosy/library.lua
@@ -1,7 +1,11 @@
 local Configuration = require "cosy.configuration"
 local Digest        = require "cosy.digest"
+local I18n          = require "cosy.i18n"
 local Value         = require "cosy.value"
 local Scheduler     = require "cosy.scheduler"
+
+local i18n   = I18n.load (require "cosy.library-i18n")
+i18n._locale = Configuration.locale._
 
 local Library   = {}
 local Client    = {}
@@ -17,7 +21,7 @@ local function threadof (f, ...)
 end
 
 function Client.connect (client)
-  local url = "ws://%{host}:%{port}/ws" % {
+  local url = "ws://{{{host}}}:{{{port}}}/ws" % {
     host = client.host,
     port = client.port,
   }
@@ -100,13 +104,13 @@ function Operation.__call (operation, parameters, try_only)
   end
   if client._status ~= "opened" then
     return nil, {
-      _ = "server:unreachable",
+      _ = i18n ["server:unreachable"],
     }
   end
   -- Special case:
   if  type (parameters) == "table"
   and parameters.username and parameters.password then
-    parameters.password = Digest ("%{username}:%{password}" % {
+    parameters.password = Digest ("{{{username}}}:{{{password}}}" % {
       username = parameters.username,
       password = parameters.password,
     })
@@ -134,7 +138,7 @@ function Operation.__call (operation, parameters, try_only)
   threadof (f)
   if result == nil then
     return nil, {
-      _ = "client:timeout",
+      _ = i18n ["server:timeout"],
     }
   elseif not result.success then
     return nil, result.error

--- a/src/cosy/loader.lua
+++ b/src/cosy/loader.lua
@@ -75,11 +75,6 @@ end
 
 do
   package.preload ["bit32"] = function ()
-    local Logger = require "cosy.logger"
-    Logger.warning {
-      _       = "fixme",
-      message = "global bit32 is created for lua-websockets",
-    }
     _G.bit32         = require "bit"
     _G.bit32.lrotate = _G.bit32.rol
     _G.bit32.rrotate = _G.bit32.ror

--- a/src/cosy/logger.lua
+++ b/src/cosy/logger.lua
@@ -5,20 +5,16 @@ local Logger = {}
 if _G.js then
   local logger = _G.window.console
   function Logger.debug (t)
-    local i18n = I18n
-    logger:log ("DEBUG: " .. i18n (t))
+    logger:log ("DEBUG: "   .. I18n (t))
   end
   function Logger.info (t)
-    local i18n = I18n
-    logger:log ("INFO: " .. i18n (t))
+    logger:log ("INFO: "    .. I18n (t))
   end
   function Logger.warning (t)
-    local i18n = I18n
-    logger:log ("WARNING: " .. i18n (t))
+    logger:log ("WARNING: " .. I18n (t))
   end
   function Logger.error (t)
-    local i18n = I18n
-    logger:log ("ERROR: " .. i18n (t))
+    logger:log ("ERROR: "   .. I18n (t))
   end
 elseif Loader.nolog then
   function Logger.debug   () end

--- a/src/cosy/methods-i18n.lua
+++ b/src/cosy/methods-i18n.lua
@@ -1,0 +1,74 @@
+return {
+  ["terms-of-service"] = {
+    en = [[
+Cas n°1: Utilisation du logiciel Cosyverif par téléchargement
+
+If you download the Cosyverif software, you acknowledge that this software is distributed under the MIT license and that you accept its terms.
+If you decline the terms of this license you must not download this software.
+
+Cas n°2: Utilisation du logiciel Cosyverif directement sur le site
+
+If you use the Cosyverif software, you acknowledge that this software is distributed under the MIT license and you accept its terms.
+If you decline the terms of this license you must not use this software.
+
+CAS 3:
+- Pour le cas que quelqu'un souhaite contribuer avec des modules, c'est moins facile. 
+ est-ce que celui qui propose le module vous donne une licence ?  et si oui, avec quels droits ?
+
+Cas 3a: A l'intention du contributeur qui veut ajouter une contribution au logiciel Cosyverif
+
+If you want that your contribution be integrated into the Cosyverif software be sure to read and accept the following provisions:
+
+By integrating your contribution into the Cosyverif software, you warrant that you are the author of the contribution and that the latter does not infringe the intellectual property rights of a third party.
+
+You assign your patrimonial rights to X for the duration of the patrimonial rights, for all territories throughout the world in order to distribute your contribution as a module of the Cosyverif software.
+It is specified that the rights assigned to X are as follows:
+- the right to reproduce the contribution in a whole,........
+- the right to represent your contribution in a whole,.....
+- the right to distribute your contribution under the MIT License
+- the right to integrate your contribution into the Cosyverif software
+
+This assignment of rights is granted for free.
+
+Cas 3b: A l'intention des utilisateurs quand la contribution est intégrée au logiciel Cosyverif sans avoir été préalablement accepté par les administrateurs réseaux
+
+Be aware the Cosyverif software contains several modules provided "as is", we do not warrant that the modules do not infringe the intellectual property rigths of a third party.
+    ]],
+  },
+  ["username:exist"] = {
+    en = "username {{{username}}} exists already",
+  },
+  ["email:exist"] = {
+    en = "email {{{email}}} is already bound to an account",
+  },
+  ["user:authenticate:failure"] = {
+    en = "authentication failed",
+  },
+  ["user:reset:from"] = {
+    en = [["{{{name}}}" <{{{email}}}>]],
+  },
+  ["user:reset:to"] = {
+    en = [["{{{name}}}" <{{{email}}}>]],
+  },
+  ["user:reset:subject"] = {
+    en = [=[[{{{servername}}}] Welcome, {{{username}}}!]=],
+  },
+  ["user:reset:body"] = {
+    en = "{{{username}}}, your validation token is <{{{validation}}}>.",
+  },
+  ["user:reset:retry"] = {
+    en = "reset failed, please try again later",
+  },
+  ["user:suspend:not-user"] = {
+    en = "account {{{username}}} is not a user",
+  },
+  ["user:suspend:self"] = {
+    en = "are you mad?",
+  },
+  ["user:suspend:not-enough"] = {
+    en = "suspending a user requires {{{required}}} reputation, but only {{{owned}}} is owned",
+  },
+  ["redis:unreachable"] = {
+    en = "redis server in unreachable",
+  },
+}

--- a/src/cosy/nginx-i18n.lua
+++ b/src/cosy/nginx-i18n.lua
@@ -1,0 +1,8 @@
+return {
+  ["nginx:no-resolver"] = {
+    en = "no resolver found for host names",
+  },
+  ["nginx:directory"] = {
+    en = "nginx runs in {{{directory}}}",
+  },
+}

--- a/src/cosy/parameters-i18n.lua
+++ b/src/cosy/parameters-i18n.lua
@@ -1,0 +1,38 @@
+return {
+  ["check:error"] = {
+    en = "some parameters are invalid or missing",
+  },
+  ["check:no-check"] = {
+    en = "request argument {{{key}}} has not been checked",
+  },
+  ["check:not-found"] = {
+    en = "parameter {{{key}}} is missing",
+  },
+  ["check:is-string"] = {
+    en = "a {{{key}}} must be a string",
+  },
+  ["check:min-size"] = {
+    en = "a {{{key}}} must contain at least {{{count}}} characters",
+  },
+  ["check:max-size"] = {
+    en = "a {{{key}}} must contain at most {{{count}}} characters",
+  },
+  ["check:alphanumeric"] = {
+    en = "a {{{key}}} must contain only alphanumeric characters",
+  },
+  ["check:email:pattern"] = {
+    en = "email address is not valid",
+  },
+  ["check:locale:pattern"] = {
+    en = "locale is not valid",
+  },
+  ["check:tos_digest:pattern"] = {
+    en = "a digest must be a sequence of hexadecimal numbers",
+  },
+  ["check:tos_digest:incorrect"] = {
+    en = "terms of service digest does not correspond to the terms of service",
+  },
+  ["check:token:invalid"] = {
+    en = "token is invalid",
+  },
+}

--- a/src/cosy/parameters.lua
+++ b/src/cosy/parameters.lua
@@ -1,8 +1,12 @@
 local Configuration = require "cosy.configuration"
+local I18n          = require "cosy.i18n"
 local Logger        = require "cosy.logger"
 local Repository    = require "cosy.repository"
 local Store         = require "cosy.store"
 local Token         = require "cosy.token"
+
+local i18n   = I18n.load (require "cosy.parameters-i18n")
+i18n._locale = Configuration.locale._
 
 local Internal      = Repository.of (Configuration) .internal
 local Parameters    = setmetatable ({}, {
@@ -21,7 +25,7 @@ function Parameters.check (request, parameters)
       local value = request [key]
       if field == "required" and value == nil then
         reasons [#reasons+1] = {
-          _   = "check:missing",
+          _   = i18n ["check:not-found"],
           key = key,
         }
       elseif value ~= nil then
@@ -47,14 +51,14 @@ function Parameters.check (request, parameters)
   for key in pairs (request) do
     if not checked [key] then
       Logger.warning {
-        _   = "check:no-check",
+        _   = i18n ["check:no-check"],
         key = key,
       }
     end
   end
   if #reasons ~= 0 then
     error {
-      _       = "check:error",
+      _       = i18n ["check:error"],
       reasons = reasons,
     }
   end
@@ -72,7 +76,7 @@ do
     local value = t.request [t.key]
     return  type (value) == "string"
         or  nil, {
-              _   = "check:is-string",
+              _   = i18n ["check:is-string"],
             }
   end
   checks [2] = function (t)
@@ -80,7 +84,7 @@ do
     local size  = t.parameter.min_size._
     return  #value >= size
         or  nil, {
-              _     = "check:min-size",
+              _     = i18n ["check:min-size"],
               count = size,
             }
   end
@@ -89,7 +93,7 @@ do
     local size  = t.parameter.max_size._
     return  #value <= size
         or  nil, {
-              _     = "check:max-size",
+              _     = i18n ["check:max-size"],
               count = size,
             }
   end
@@ -128,7 +132,7 @@ do
     local value = t.request [t.key]
     return  value:find "^%w[%w%-_]+$"
         or  nil, {
-              _        = "check:username:alphanumeric",
+              _        = i18n ["check:alphanumeric"],
               username = value,
             }
   end
@@ -158,7 +162,7 @@ do
     local pattern = "^.*@[%w%.%%%+%-]+%.%w%w%w?%w?$"
     return  value:find (pattern)
         or  nil, {
-              _     = "check:email:pattern",
+              _     = i18n ["check:email:pattern"],
               email = value,
             }
   end
@@ -186,9 +190,10 @@ do
   checks [Repository.size (checks)+1] = function (t)
     local value = t.request [t.key]
     return  value:find "^%a%a$"
-        or  value:find "^%a%a_%a%a$"
+        or  value:find "^%a%a%-%a%a$"
+        or  value:find "^%a%a%_%a%a$"
         or  nil, {
-              _      = "check:locale:pattern",
+              _      = i18n ["check:locale:pattern"],
               locale = value,
             }
   end
@@ -214,7 +219,7 @@ do
     local pattern = "^%x+$"
     return  value:find (pattern)
         or  nil, {
-              _          = "check:tos_digest:pattern",
+              _          = i18n ["check:tos_digest:pattern"],
               tos_digest = value,
             }
   end
@@ -225,7 +230,7 @@ do
     local tos = Methods.tos { locale = request.locale }
     return  tos.tos_digest == value
         or  nil, {
-              _          = "check:tos_digest:incorrect",
+              _          = i18n ["check:tos_digest:incorrect"],
               tos_digest = value,
             }
   end
@@ -247,7 +252,7 @@ do
     local ok, result = pcall (Token.decode, value)
     if not ok then
       return nil, {
-        _ = "check:token:invalid",
+        _ = i18n ["check:token:invalid"],
       }
     end
     request [key] = result.contents
@@ -269,7 +274,7 @@ do
     local value   = request [t.key]
     return  value.type == "administration"
         or  nil, {
-              _ = "check:token:invalid",
+              _ = i18n ["check:token:invalid"],
             }
   end
   checks [Repository.size (checks)+1] = function (t)
@@ -278,7 +283,7 @@ do
     local Server  = require "cosy.server"
     return  value.passphrase == Server.passphrase
         or  nil, {
-              _ = "check:token:invalid",
+              _ = i18n ["check:token:invalid"],
             }
   end
 end
@@ -297,7 +302,7 @@ do
     local value   = request [t.key]
     return  value.type == "validation"
         or  nil, {
-              _ = "check:token:invalid",
+              _ = i18n ["check:token:invalid"],
             }
   end
 end
@@ -316,7 +321,7 @@ do
     local value   = request [t.key]
     return  value.type == "authentication"
         or  nil, {
-              _ = "check:token:invalid",
+              _ = i18n ["check:token:invalid"],
             }
   end
   checks [Repository.size (checks)+1] = function (t)
@@ -328,7 +333,7 @@ do
        and  user.type   == Methods.Type.user
        and  user.status == Methods.Status.active
         or  nil, {
-              _ = "check:token:invalid",
+              _ = i18n ["check:token:invalid"],
             }
   end
 end

--- a/src/cosy/password-i18n.lua
+++ b/src/cosy/password-i18n.lua
@@ -1,0 +1,5 @@
+return {
+  ["bcrypt:rounds"] = {
+    en = "using {{{rounds}}} rounds in bcrypt for at least {{{time}}} milliseconds of computation",
+  },
+}

--- a/src/cosy/password.lua
+++ b/src/cosy/password.lua
@@ -3,9 +3,13 @@ if _G.js then
 end
 
 local Configuration = require "cosy.configuration"
+local I18n          = require "cosy.i18n"
 local Logger        = require "cosy.logger"
 local Time          = require "cosy.time"
 local Bcrypt        = require "bcrypt"
+
+local i18n   = I18n.load (require "cosy.password-i18n")
+i18n._locale = Configuration.locale._
 
 local Password = {}
 
@@ -43,9 +47,9 @@ end
 do
   compute_rounds ()
   Logger.debug {
-    _     = "bcrypt:rounds",
-    count = Password.rounds,
-    time  = Configuration.data.password.time._ * 1000,
+    _      = i18n ["bcrypt:rounds"],
+    rounds = Password.rounds,
+    time   = Configuration.data.password.time._ * 1000,
   }
 end
 

--- a/src/cosy/server-i18n.lua
+++ b/src/cosy/server-i18n.lua
@@ -1,0 +1,11 @@
+return {
+  ["message:invalid"] = {
+    en = "rpc message is invalid",
+  },
+  ["message:no-operation"] = {
+    en = "operation {{{operation}}} does not exist",
+  },
+  ["websocket:listen"] = {
+    en = "server websocket listening on {{{host}}}:{{{port}}}",
+  },
+}

--- a/src/cosy/server.lua
+++ b/src/cosy/server.lua
@@ -18,11 +18,13 @@ local Lfs           = require "lfs"
 local Socket        = require "socket"
       Socket.unix   = require "socket.unix"
 
+local i18n   = I18n.load (require "cosy.server-i18n")
+i18n._locale = Configuration.locale._
 local Server = {}
 
 function Server.request (message)
   local function translate (x)
-    I18n (x)
+    i18n (x)
     return x
   end
   local decoded, request = pcall (Value.decode, message)
@@ -30,8 +32,7 @@ function Server.request (message)
     return Value.expression (translate {
       success = false,
       error   = {
-        _      = "rpc:invalid",
-        reason = message,
+        _ = i18n ["message:invalid"],
       },
     })
   end
@@ -50,7 +51,7 @@ function Server.request (message)
       identifier = identifier,
       success    = false,
       error      = {
-        _      = "rpc:no-operation",
+        _      = i18n ["message:no-operation"],
         reason = operation,
       },
     })
@@ -106,7 +107,7 @@ function Server.start ()
   }
   Scheduler.addserver = addserver
   Logger.debug {
-    _    = "server:listening",
+    _    = i18n ["websocket:listen"],
     host = Configuration.server.interface._,
     port = Configuration.server.port._,
   }
@@ -119,7 +120,7 @@ function Server.start ()
       port      = Configuration.server.port._,
     })
     file:close ()
-    os.execute ([[ chmod 0600 %{file} ]] % { file = datafile })
+    os.execute ([[ chmod 0600 {{{file}}} ]] % { file = datafile })
   end
   do
     Nginx.stop  ()
@@ -131,7 +132,7 @@ function Server.start ()
     local file    = io.open (pidfile, "w")
     file:write (Ffi.C.getpid ())
     file:close ()
-    os.execute ([[ chmod 0600 %{file} ]] % { file = pidfile })
+    os.execute ([[ chmod 0600 {{{file}}} ]] % { file = pidfile })
   end
   Scheduler.loop ()
 end

--- a/src/cosy/string.lua
+++ b/src/cosy/string.lua
@@ -1,33 +1,10 @@
-local metatable = getmetatable ""
-local string    = string
+local Lustache      = require "lustache"
+local metatable     = getmetatable ""
+local string        = string
 
---    > require "cosy.string"
-
--- taken from i18n/interpolate
 metatable.__mod = function (pattern, variables)
-  variables = variables or {}
-  return pattern:gsub ("(.?)%%{(.-)}", function (previous, key)
-    if previous == "%" then
-      return
-    end
-    local value = tostring (variables [key])
-    return previous .. value
-  end)
+  return Lustache:render (pattern, variables)
 end
-
---    > = "%{_1}-%{_2}-%{_3}" % {
---    >     _1 = "abc",
---    >     _2 = true,
---    >     _3 = nil,
---    >   }
---    "abc-true-nil"
-
---    > = "%%{_1}-%%{_2}-%%{_3}" % {
---    >     _1 = "abc",
---    >     _2 = true,
---    >     _3 = nil,
---    >   }
---    "%%{_1}-%%{_2}-%%{_3}"
 
 -- http://stackoverflow.com/questions/9790688/escaping-strings-for-gsub
 function string.escape (s)
@@ -46,68 +23,16 @@ function string.escape (s)
         :gsub('%?', '%%%?')
 end
 
-metatable.__div = function (pattern, s)
-  local names = {}
-  pattern = pattern:escape ()
-  pattern = pattern:gsub ("(.?)%%%%{(.-)}", function (previous, key)
-    if previous == "%" then
-      return
-    end
-    names [#names+1] = key
-    return previous .. "(.*)"
-  end)
-  if pattern:sub (1,1) ~= "^" then
-    pattern = "^" .. pattern
-  end
-  if pattern:sub (-1,1) ~= "$" then
-    pattern = pattern .. "$"
-  end
-  local results = { s:match (pattern) }
-  if #results == 0 then
-    return nil
-  end
-  local result  = {}
-  for i = 1, #names do
-    result [names [i]] = results [i]
-  end
-  return result
-end
-
---    > = "abc%{key}xyz" / "abcdefxyz"
---    { key = "def" }
-
---    > = "abc%{key}xyz" / "abcdefijk"
---    nil
-
---    > = "abc%%{key}xyz" / "abcdefxyz"
---    nil
-
 function string.quote (s)
   return string.format ("%q", s)
 end
-
---    > local text = "abc"
---    > = text:quote ()
---    [["abc"]]
 
 function string.is_identifier (s)
   local i, j = s:find ("[_%a][_%w]*")
   return i == 1 and j == #s
 end
 
---    > local text = "abc"
---    > = text:is_identifier ()
---    true
-
---    > local text = "0abc"
---    > = text:is_identifier ()
---    false
-
 -- http://lua-users.org/wiki/StringTrim
 function string.trim (s)
   return s:match "^()%s*$" and "" or s:match "^%s*(.*%S)"
 end
-
---    > local text = "   abc   def   "
---    > = text:trim ()
---    "abc   def"

--- a/src/cosy/token-i18n.lua
+++ b/src/cosy/token-i18n.lua
@@ -1,0 +1,5 @@
+return {
+  ["token:no-secret"] = {
+    en = "token secret is not defined in configuration.token.secret",
+  },
+}

--- a/src/cosy/token.lua
+++ b/src/cosy/token.lua
@@ -4,14 +4,17 @@ end
 
 local Configuration = require "cosy.configuration"
 local Digest        = require "cosy.digest"
+local I18n          = require "cosy.i18n"
 local Random        = require "cosy.random"
 local Time          = require "cosy.time"
-
 local Jwt           = require "luajwt"
+
+local i18n   = I18n.load (require "cosy.token-i18n")
+i18n._locale = Configuration.locale._
 
 if Configuration.token.secret._ == nil then
   error {
-    _ = "token:no-secret",
+    _ = i18n ["token:no-secret"],
   }
 end
 


### PR DESCRIPTION
Internationalization now uses [lustache](https://github.com/Olivine-Labs/lustache) for patterns, and [i18n](https://github.com/kikito/i18n.lua) for plural rules.

I18n is also split in several files (one for each module) to help maintainance. The format is **not** the one of [i18n](https://github.com/kikito/i18n.lua). Instead we put all translations in the message entry.