### PR TITLE
Do not create lua bundle if in developer mode.

### DIFF
--- a/src/cosy/nginx/init.lua
+++ b/src/cosy/nginx/init.lua
@@ -273,7 +273,7 @@ http {
   function Nginx.bundle ()
     os.remove (Configuration.http.bundle)
     Scheduler.addthread (function ()
-      if Nginx.in_bundle then
+      if Nginx.in_bundle or Configuration.dev_mode then
         return
       end
       Nginx.in_bundle = true


### PR DESCRIPTION
Fix #187 

Please add to your `cosy.conf`:

```lua
return {
  dev_mode = true,
}
```